### PR TITLE
[Feat] #21 - 연락처 스와이프 삭제

### DIFF
--- a/myContacts/myContacts/Controller/ViewController.swift
+++ b/myContacts/myContacts/Controller/ViewController.swift
@@ -72,5 +72,26 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         vc.existingContact = contact
         navigationController?.pushViewController(vc, animated: true)
     }
+    
+    func tableView(_ tableView: UITableView,
+                   trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { _, _, completion in
+            let ctx = CoreDataStack.context
+            let target = self.contacts[indexPath.row]
+
+            ctx.delete(target)
+            do {
+                try ctx.save()
+                self.contacts.remove(at: indexPath.row)
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+                completion(true)
+            } catch {
+                print("삭제 에러:", error)
+                completion(false)
+            }
+        }
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
 }
 


### PR DESCRIPTION
### 작업한 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

**뷰컨트롤러**에서 테이블뷰 메서드들 아래에 삭제 메서드 추가함

```swift
    func tableView(_ tableView: UITableView,
                   trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { _, _, completion in
            let ctx = CoreDataStack.context
            let target = self.contacts[indexPath.row]

            ctx.delete(target)
            do {
                try ctx.save()
                self.contacts.remove(at: indexPath.row)
                tableView.deleteRows(at: [indexPath], with: .automatic)
                completion(true)
            } catch {
                print("삭제 에러:", error)
                completion(false)
            }
        }
        return UISwipeActionsConfiguration(actions: [deleteAction])
    }
```
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Plus - 2025-10-02 at 20 06 11" src="https://github.com/user-attachments/assets/09856201-12c2-42ce-8bc5-1e20345e6d76" />

셀 스와이프 삭제하면 디스크에도 반영됨

### 관련 이슈
Closes #21

### PR 올리기 전 Check List
Merge 대상 브랜치가 올바른가? 네

작업한 코드가 에러 없이 잘 동작하는가? 네

